### PR TITLE
Fix FEN format when launching engine searches

### DIFF
--- a/game.py
+++ b/game.py
@@ -230,7 +230,14 @@ class UCIEngine:
         self.drain()
 
         # set position + go
-        self._send(f"position fen {board.fen()}")
+        # Some UCI engines only understand the first four fields of a FEN
+        # string (piece placement, side to move, castling rights and
+        # en-passant square).  python-chess' ``Board.fen()`` includes the
+        # halfmove clock and fullmove number which can confuse such parsers
+        # and result in an "0000" move.  Strip those counters to keep the
+        # engine in sync with the GUI.
+        fen = " ".join(board.fen().split()[:4])
+        self._send(f"position fen {fen}")
         self._send(f"go movetime {movetime_ms}")
 
         info: list[str] = []


### PR DESCRIPTION
## Summary
- Ensure UCI position commands omit halfmove and move counters
- Prevent engines from replying with `0000` in self-play

## Testing
- `python -m py_compile game.py`


------
https://chatgpt.com/codex/tasks/task_e_68a18acee024832d8143844fc3eae62a