### PR TITLE
Use shredder FEN for reliable engine moves

### DIFF
--- a/game.py
+++ b/game.py
@@ -230,13 +230,11 @@ class UCIEngine:
         self.drain()
 
         # set position + go
-        # Some UCI engines only understand the first four fields of a FEN
-        # string (piece placement, side to move, castling rights and
-        # en-passant square).  python-chess' ``Board.fen()`` includes the
-        # halfmove clock and fullmove number which can confuse such parsers
-        # and result in an "0000" move.  Strip those counters to keep the
-        # engine in sync with the GUI.
-        fen = " ".join(board.fen().split()[:4])
+        # Use ``shredder_fen()`` to omit the halfmove clock and fullmove
+        # number from the FEN sent to the engine.  Some UCI engines only
+        # parse the first four FEN fields and may respond with the bogus
+        # move ``0000`` if the additional counters are present.
+        fen = board.shredder_fen()
         self._send(f"position fen {fen}")
         self._send(f"go movetime {movetime_ms}")
 


### PR DESCRIPTION
## Summary
- Avoid illegal or stale engine moves by sending `shredder_fen()` to the engine, omitting halfmove and fullmove counters that can confuse some UCI engines.

## Testing
- `python -m py_compile game.py`


------
https://chatgpt.com/codex/tasks/task_e_68a18df66bd0832d88df4d932dc4e0b0